### PR TITLE
fix setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,16 @@
 [metadata]
 name=r53spflat
 version=22.02.20
-author = gunville
-author_email = rk13088@yahoo.com
+author = weizenspreu
+author_email = kevin.niehage@staffbase.com
 description = Flattens SPF records and updates Cloudflare zones
 long_description = file: README.md
 long_description_content_type = text/markdown
 license_files = LICENSE.txt
-url = https://github.com/Glocktober/r53spflat
+url = https://github.com/Staffbase/r53spflat
 project_urls =
-    repo = https://github.com/Glocktober/r53spflat.git
-    overview = https://github.com/Glocktober/r53spflat/blob/master/README.md
+    repo = https://github.com/Staffbase/r53spflat.git
+    overview = https://github.com/Staffbase/r53spflat/blob/master/README.md
 classifiers = 
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License
@@ -22,8 +22,8 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    boto3>=1.21.2
-    sender-policy-flattener @ https://github.com/staffbase/sender_policy_flattener/tarball/master
+    boto3>=1.21.3
+    sender-policy-flattener @ https://github.com/staffbase/r53spflat/archive/3cedd9b83cdf30a7a66e8dbf63696fc3ffe52a1a.tar.gz
 python_requires = >=3.6
 scripts = 
     scripts/r53spflat

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ license_files = LICENSE.txt
 url = https://github.com/Staffbase/r53spflat
 project_urls =
     repo = https://github.com/Staffbase/r53spflat.git
-    overview = https://github.com/Staffbase/r53spflat/blob/master/README.md
+    overview = https://github.com/Staffbase/r53spflat/blob/main/README.md
 classifiers = 
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    boto3>=1.21.3
+    boto3>=1.23.3
     sender-policy-flattener @ https://github.com/staffbase/sender_policy_flattener/archive/b9f0658573ca906a493d012fe8138e4ebd1c0fed.tar.gz
 python_requires = >=3.6
 scripts = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir =
 packages = find:
 install_requires =
     boto3>=1.21.3
-    sender-policy-flattener @ https://github.com/staffbase/r53spflat/archive/3cedd9b83cdf30a7a66e8dbf63696fc3ffe52a1a.tar.gz
+    sender-policy-flattener @ https://github.com/staffbase/sender_policy_flattener/archive/b9f0658573ca906a493d012fe8138e4ebd1c0fed.tar.gz
 python_requires = >=3.6
 scripts = 
     scripts/r53spflat

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name=r53spflat
 version=22.02.20
 author = weizenspreu
 author_email = kevin.niehage@staffbase.com
-description = Flattens SPF records and updates Cloudflare zones
+description = Flattens SPF records and updates Route53 zones
 long_description = file: README.md
 long_description_content_type = text/markdown
 license_files = LICENSE.txt
@@ -23,6 +23,8 @@ package_dir =
 packages = find:
 install_requires =
     boto3>=1.23.3
+    dnspython>=2.2.0
+    netaddr>=0.8.0
     sender-policy-flattener @ https://github.com/staffbase/sender_policy_flattener/archive/b9f0658573ca906a493d012fe8138e4ebd1c0fed.tar.gz
 python_requires = >=3.6
 scripts = 


### PR DESCRIPTION
<!-- ai-pr-description:start -->
## Summary

This PR updates `setup.cfg` metadata to reflect the Staffbase fork ownership and fixes the `install_requires` section to make `r53spflat` directly installable via a locked requirements file.

## Changes

- Updates author, email, description, and repository URLs to point to the Staffbase organization and fork
- Pins `sender-policy-flattener` dependency to a specific commit hash instead of a branch tip, enabling reproducible installs
- Bumps `boto3` minimum version and adds explicit `dnspython` and `netaddr` dependencies

🤖 Generated with [Staffbase AI Review Swarm](https://ai-review-swarm.staffbase.workers.dev/admin)
<!-- ai-pr-description:end -->

Let's try to make r53spflat installable directly via a requirements-lock.txt file.
